### PR TITLE
feat: xml2rfc is now published as a separate chocolatey package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,52 +27,13 @@ jobs:
       - name: Pack Chocolatey package
         run: choco pack
 
-      # Install GitHub CLI
-      - name: Install GitHub CLI
-        run: choco install gh -y --no-progress
-        shell: powershell
-
-      # Download xml2rfc dependency for Docker builds
-      - name: Get latest xml2rfc release and download package
-        run: |
-          Write-Host "Getting latest xml2rfc release..." -ForegroundColor Yellow
-          $release = gh release view --repo metanorma/chocolatey-xml2rfc --json tagName,assets | ConvertFrom-Json
-          $version = $release.tagName
-          $versionNumber = $version.TrimStart('v')
-          $filename = "xml2rfc.$versionNumber.nupkg"
-          Write-Host "Latest version: $version"
-          Write-Host "Downloading xml2rfc package: $filename"
-          gh release download $version --repo metanorma/chocolatey-xml2rfc --pattern $filename
-          Write-Host "Downloaded xml2rfc package: $filename" -ForegroundColor Green
-        shell: powershell
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/upload-artifact@v4
         with:
           name: nupkg
-          path: |
-            metanorma.*.nupkg
-            xml2rfc.*.nupkg
+          path: metanorma.*.nupkg
 
-      # Install dependencies first, then xml2rfc from local package
-      - name: Install xml2rfc
-        run: choco install xml2rfc --source="'$(Get-Location);chocolatey'" -y --no-progress
-        shell: powershell
-
-      # Verify xml2rfc executable is available
-      - name: Verify xml2rfc installation
-        shell: powershell
-        run: |
-          if (Get-Command "xml2rfc" -ErrorAction SilentlyContinue) {
-            Write-Host "[OK] xml2rfc executable found"
-            xml2rfc --version
-          } else {
-            Write-Error "xml2rfc not available - IETF support requires xml2rfc"
-            exit 1
-          }
-
-      # Install metanorma from local package and verify installation
+      # Install metanorma from local package
       - name: Install metanorma
         shell: powershell
         run: choco install metanorma --source="'$(Get-Location);chocolatey'" -y --no-progress
@@ -86,6 +47,18 @@ jobs:
             metanorma version
           } else {
             Write-Error "metanorma executable not found in PATH"
+            exit 1
+          }
+
+      # Verify xml2rfc dependency is available
+      - name: Verify xml2rfc dependency
+        shell: powershell
+        run: |
+          if (Get-Command "xml2rfc" -ErrorAction SilentlyContinue) {
+            Write-Host "[OK] xml2rfc dependency found"
+            xml2rfc --version
+          } else {
+            Write-Error "xml2rfc dependency not available - IETF support requires xml2rfc"
             exit 1
           }
 
@@ -125,7 +98,8 @@ jobs:
           name: nupkg
           path: test
 
-      # unfortunatelly windows docker image too big to prebuild it once
+      # Unfortunately the Windows docker image is too big to prebuild it in one
+      # step and push to Docker Hub.
       - run: docker build -t metanorma-docker-test .
         working-directory: test
 
@@ -175,24 +149,7 @@ jobs:
         with:
           name: nupkg
 
-      # Install dependencies first, then xml2rfc from local package
-      - name: Install xml2rfc
-        run: choco install xml2rfc --source="'$(Get-Location);chocolatey'" -y --no-progress
-        shell: powershell
-
-      # Verify xml2rfc executable is available
-      - name: Verify xml2rfc installation
-        shell: powershell
-        run: |
-          if (Get-Command "xml2rfc" -ErrorAction SilentlyContinue) {
-            Write-Host "[OK] xml2rfc executable found"
-            xml2rfc --version
-          } else {
-            Write-Error "xml2rfc not available - IETF support requires xml2rfc"
-            exit 1
-          }
-
-      # Install metanorma from local package and verify installation
+      # Install metanorma from local package
       - name: Install metanorma
         shell: powershell
         run: choco install metanorma --source="'$(Get-Location);chocolatey'" -y --no-progress
@@ -206,6 +163,18 @@ jobs:
             metanorma version
           } else {
             Write-Error "metanorma executable not found in PATH"
+            exit 1
+          }
+
+      # Verify xml2rfc dependency is available
+      - name: Verify xml2rfc dependency
+        shell: powershell
+        run: |
+          if (Get-Command "xml2rfc" -ErrorAction SilentlyContinue) {
+            Write-Host "[OK] xml2rfc dependency found"
+            xml2rfc --version
+          } else {
+            Write-Error "xml2rfc dependency not available - IETF support requires xml2rfc"
             exit 1
           }
 

--- a/README.adoc
+++ b/README.adoc
@@ -25,12 +25,10 @@ Key dependencies include:
 * `plantuml` (version 1.2025.2+)
 * `inkscape` (version 1.4.0+)
 * `graphviz` (version 2.28.0+)
-* `xml2rfc` (version 3.0.0+) (hosted at https://github.com/metanorma/chocolatey-xml2rfc[chocolatey-xml2rfc])
+* `xml2rfc` (version 3.0.0+)
 
 When installing Metanorma via Chocolatey, all dependencies are resolved
 automatically.
-
-NOTE: Users do not need to manually install xml2rfc as previously required.
 
 
 == Using Metanorma in Windows Docker containers
@@ -102,7 +100,7 @@ pwsh -ExecutionPolicy Bypass -File test/test_installation.ps1 -TestUninstall -Ve
 The test script validates:
 
 * Metanorma executable download and registration
-* xml2rfc dependency handling via chocolatey-xml2rfc package
+* xml2rfc dependency handling
 * Enhanced installation verification and error handling
 * Uninstallation and cleanup procedures
 * Windows Chocolatey package functionality

--- a/metanorma.nuspec
+++ b/metanorma.nuspec
@@ -29,7 +29,6 @@
       <dependency id="git" version="[2.50.0,)"/>
       <dependency id="python3" version="[3.13.0,)"/>
       <dependency id="openjdk" version="[22.0.2,)"/>
-      <dependency id="plantuml" version="[1.2025.2,)"/>
       <dependency id="inkscape" version="[1.4.0,)"/>
       <dependency id="graphviz" version="[2.28.0,)"/>
       <dependency id="xml2rfc" version="[3.0.0,)"/>

--- a/metanorma.nuspec
+++ b/metanorma.nuspec
@@ -27,7 +27,6 @@
   We constantly recheck VirusTotal reports and can confirm that reported issues are false-positive]]></description>
     <dependencies>
       <dependency id="git" version="[2.50.0,)"/>
-      <dependency id="python3" version="[3.13.0,)"/>
       <dependency id="openjdk" version="[22.0.2,)"/>
       <dependency id="inkscape" version="[1.4.0,)"/>
       <dependency id="graphviz" version="[2.28.0,)"/>

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,11 +18,11 @@ RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1; \
     refreshenv
 
-### Install xml2rfc and metanorma packages in a separate layer
+### Install metanorma and dependencies in a separate layer
 FROM chocolatey AS packages
 
-# Copy both packages to a dedicated directory
-COPY *.nupkg C:/packages/
+# Copy metanorma package to a dedicated directory
+COPY metanorma.*.nupkg C:/packages/
 
 # Debug: List files to verify COPY worked and show choco version
 RUN Write-Host '=== Chocolatey Version ==='; \
@@ -35,22 +35,7 @@ RUN Write-Host '=== Chocolatey Version ==='; \
 # Enable global confirmation for Chocolatey commands
 RUN choco feature enable -n allowGlobalConfirmation
 
-# Install xml2rfc from local package
-RUN choco install xml2rfc --source='C:\packages;chocolatey' -y --no-progress
-
-# Verify xml2rfc executables are available
-RUN if (Get-Command 'xml2rfc' -ErrorAction SilentlyContinue) { \
-        Write-Host '[OK] xml2rfc executable found'; \
-        & xml2rfc --version \
-    } else { \
-        Write-Error 'xml2rfc not available - IETF support requires xml2rfc'; \
-        exit 1 \
-    };
-
-RUN Write-Host '=== Verifying xml2rfc installation ==='; \
-    choco list xml2rfc --limit-output
-
-# Install metanorma from local package and verify installation
+# Install metanorma from local package (xml2rfc installed automatically as dependency)
 RUN choco install metanorma --source='C:\packages;chocolatey' -y --no-progress
 
 # Verify metanorma executables are available
@@ -59,6 +44,15 @@ RUN if (Get-Command 'metanorma' -ErrorAction SilentlyContinue) { \
         & metanorma version \
     } else { \
         Write-Error 'metanorma executable not found in PATH'; \
+        exit 1 \
+    };
+
+# Verify xml2rfc dependency is available
+RUN if (Get-Command 'xml2rfc' -ErrorAction SilentlyContinue) { \
+        Write-Host '[OK] xml2rfc dependency found'; \
+        & xml2rfc --version \
+    } else { \
+        Write-Error 'xml2rfc dependency not available - IETF support requires xml2rfc'; \
         exit 1 \
     };
 


### PR DESCRIPTION
feat: xml2rfc is now published as a separate chocolatey package

Also removed plantuml and python packages since they are no longer direct dependencies.